### PR TITLE
Ignore Unknown Arguments

### DIFF
--- a/clipr/Core/ParserConfig.cs
+++ b/clipr/Core/ParserConfig.cs
@@ -91,7 +91,9 @@ namespace clipr.Core
 
         internal readonly HashSet<string> RequiredMutuallyExclusiveArguments;
 
-        internal readonly HashSet<string> RequiredNamedArguments; 
+        internal readonly HashSet<string> RequiredNamedArguments;
+
+        internal readonly bool IgnoreUnknownArguments;
 
         public IEnumerable<ITrigger<T>> Triggers { get; set; }
 
@@ -110,6 +112,9 @@ namespace clipr.Core
                 ShortNameArguments = new Dictionary<char, IShortNameArgument>();
                 LongNameArguments = new Dictionary<string, ILongNameArgument>();
             }
+
+            if (options.HasFlag(ParserOptions.IgnoreUnknown))
+                IgnoreUnknownArguments = true;
 
             PositionalArguments = new List<IPositionalArgument>();
             Verbs = new Dictionary<string, VerbConfig>();

--- a/clipr/Core/ParsingContext.cs
+++ b/clipr/Core/ParsingContext.cs
@@ -148,9 +148,10 @@ namespace clipr.Core
 
             if (positionalArgStack.Count > 0)
             {
-                throw new ParseException(null, String.Format(
-                    "Extra positional arguments found: {0}",
-                    String.Join(" ", positionalArgStack.ToArray())));
+                if(!Config.IgnoreUnknownArguments)
+                    throw new ParseException(null, String.Format(
+                        "Extra positional arguments found: {0}",
+                        String.Join(" ", positionalArgStack.ToArray())));
             }
 
             ParsingCleanup();

--- a/clipr/Core/ParsingContext.cs
+++ b/clipr/Core/ParsingContext.cs
@@ -181,6 +181,8 @@ namespace clipr.Core
             INamedArgumentBase arg;
             if (!argDict.TryGetValue(name, out arg))
             {
+                if (Config.IgnoreUnknownArguments)
+                    return;
                 throw new ParseException(name.ToString(), String.Format(
                     "Unknown argument name '{0}'.", name));
             }

--- a/clipr/ParserOptions.cs
+++ b/clipr/ParserOptions.cs
@@ -16,6 +16,11 @@ namespace clipr
         /// <summary>
         /// Make short and long argument comparisons case insensitive.
         /// </summary>
-        CaseInsensitive = 1
+        CaseInsensitive = 1,
+
+        /// <summary>
+        /// Ignore unknown arguments.
+        /// </summary>
+        IgnoreUnknown = 2
     }
 }


### PR DESCRIPTION
This adds `ParserOptions.IgnoreUnknown` which will suppress parsing errors pertaining to unknown arguments and extra positional arguments.

My use case is to support a situation where there are several independently defined options classes and no single options class would be able to interpret all the command line arguments. This allows the independent parsers to parse the arguments they understand and ignore what they don't.