### PR TITLE
Fix #22: Improved type conversion error message

### DIFF
--- a/clipr.UnitTests/HelpGeneratorUnitTest.cs
+++ b/clipr.UnitTests/HelpGeneratorUnitTest.cs
@@ -1,11 +1,41 @@
-﻿using clipr.Usage;
+﻿using clipr.Core;
+using clipr.Usage;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace clipr.UnitTests
 {
+    class NoDescription
+    {
+        [NamedArgument("name")]
+        public string Name { get; set; }
+    }
+
+    class Help: AutomaticHelpGenerator<NoDescription>
+    {
+        public Help()
+        {
+            ShortName = null;
+            LongName = "help";
+        }
+    }
+
     [TestClass]
     public class HelpGeneratorUnitTest
     {
+        [TestMethod]
+        [ExpectedException(typeof(ParserExit))]
+        public void Help_WithNoDescription_NoNullPointer()
+        {
+
+            var args = "--help".Split();
+            var opt = new NoDescription();
+            var parser = new CliParser<NoDescription>(
+                opt,
+                ParserOptions.None,
+                new Help());
+            parser.Parse(args);
+        }
+        
         [StaticEnumeration]
         internal class MyEnum
         {

--- a/clipr/Core/ParsingContext.cs
+++ b/clipr/Core/ParsingContext.cs
@@ -213,7 +213,10 @@ namespace clipr.Core
                 throw new ParseException(name.ToString(),
                     "Arguments that consume values cannot be grouped.");
             }
-            ParseArgument(name.ToString(), arg, iter, positionalDelimiterFound);
+            if (name is char)
+                ParseArgument(Config.ArgumentPrefix.ToString() + name.ToString(), arg, iter, positionalDelimiterFound);
+            else
+                ParseArgument(Config.ArgumentPrefix.ToString() + Config.ArgumentPrefix.ToString() + name.ToString(), arg, iter, positionalDelimiterFound);
         }
 
         private void ParsePositionalArguments(Stack<string> args, bool positionalDelimiterFound)
@@ -229,6 +232,7 @@ namespace clipr.Core
         /// </summary>
         /// <param name="attrName">
         /// Name of the argument (whether short, long, or positional).
+        /// e.g. "-v", "--verbose", "VALUE"
         /// </param>
         /// <param name="arg">Property associated with the argument.</param>
         /// <param name="positionalDelimiterFound">True if the positional delimiter, e.g. -- has been found.</param>
@@ -258,17 +262,17 @@ namespace clipr.Core
                                 else
                                 {
                                     throw new ParseException(attrName, String.Format(
-                                        @"Value ""{0}"" cannot be converted to the " +
-                                        "required type {1}.",
-                                        stringValue, store.Type));
+                                        @"Argument {0} value ""{1}"" cannot be converted to the " +
+                                        "required type {2}.",
+                                        attrName, stringValue, store.Type));
                                 }
                             }
                             catch (Exception e)
                             {
                                 throw new ParseException(attrName, String.Format(
-                                    @"Value ""{0}"" cannot be converted to the " +
-                                    "required type {1}.",
-                                    stringValue, store.Type), e);
+                                    @"Argument {0} value ""{1}"" cannot be converted to the " +
+                                    "required type {2}.",
+                                     attrName, stringValue, store.Type), e);
                             }
                         }
                         else
@@ -315,17 +319,17 @@ namespace clipr.Core
                                 else
                                 {
                                     throw new ParseException(attrName, String.Format(
-                                        @"Value ""{0}"" cannot be converted to the " +
-                                        "required type {1}.",
-                                        stringValue, arg.Store.Type));
+                                        @"Argument {0} value ""{1}"" cannot be converted to the " +
+                                        "required type {2}.",
+                                        attrName, stringValue, arg.Store.Type));
                                 }
                             }
                             catch (Exception e)
                             {
                                 throw new ParseException(attrName, String.Format(
-                                    @"Value ""{0}"" cannot be converted to the " +
-                                    "required type {1}.",
-                                    stringValue, store.Type), e);
+                                    @"Argument {0} value ""{1}"" cannot be converted to the " +
+                                    "required type {2}.",
+                                    attrName, stringValue, store.Type), e);
                             }
                         }
                         else
@@ -403,17 +407,17 @@ namespace clipr.Core
                     else
                     {
                         throw new ParseException(attrName, String.Format(
-                            @"Value ""{0}"" cannot be converted to the " +
-                            "required type {1}.",
-                            stringValue, arg.Store.Type));
+                            @"Argument {0} value ""{1}"" cannot be converted to the " +
+                            "required type {2}.",
+                            attrName, stringValue, arg.Store.Type));
                     }
                 }
                 catch (Exception e)
                 {
                     throw new ParseException(attrName, String.Format(
-                        @"Value ""{0}"" cannot be converted to the " +
-                        "required type {1}.",
-                        stringValue, arg.Store.Type), e);
+                        @"Argument {0} value ""{1}"" cannot be converted to the " +
+                        "required type {2}.",
+                        attrName, stringValue, arg.Store.Type), e);
                 }
                 argsProcessed++;
             }

--- a/clipr/Usage/AutomaticHelpGenerator.cs
+++ b/clipr/Usage/AutomaticHelpGenerator.cs
@@ -349,7 +349,7 @@ namespace clipr.Usage
             return new ArgumentDisplay
             {
                 ArgumentNames = String.Join(", ", names.ToArray()),
-                Description = attr.Description
+                Description = attr.Description ?? ""
             };
         }
 


### PR DESCRIPTION
Show switch that user types, e.g. -n or --name when type can not be converted, e.g:

    Argument --value value "2x" cannot be converted to the required type System.Int32.